### PR TITLE
Resolving UserMergeOptions Object

### DIFF
--- a/src/main/java/hudson/plugins/git/extensions/impl/PreBuildMerge.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/PreBuildMerge.java
@@ -115,8 +115,50 @@ public class PreBuildMerge extends GitSCMExtension {
         return GitClientType.GITCLI;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        if (o instanceof PreBuildMerge) {
+            PreBuildMerge that = (PreBuildMerge) o;
+            return (options != null && options.equals(that.options))
+                    || (options == null && that.options == null);
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return PreBuildMerge.class.hashCode();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return "PreBuildMerge{" +
+                "options=" + options.toString() +
+                '}';
+    }
+
     @Extension
     public static class DescriptorImpl extends GitSCMExtensionDescriptor {
+        /**
+         * {@inheritDoc}
+         */
         @Override
         public String getDisplayName() {
             return "Merge before build";

--- a/src/main/java/jenkins/plugins/git/GitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMSource.java
@@ -424,7 +424,7 @@ public class GitSCMSource extends AbstractGitSCMSource {
             return Messages.GitSCMSource_DisplayName();
         }
 
-        public ListBoxModel doFillCredentialsIdItems(@AncestorInPath SCMSourceOwner context,
+        public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item context,
                                                      @QueryParameter String remote,
                                                      @QueryParameter String credentialsId) {
             if (context == null && !Jenkins.getActiveInstance().hasPermission(Jenkins.ADMINISTER) ||
@@ -441,8 +441,8 @@ public class GitSCMSource extends AbstractGitSCMSource {
                             GitClient.CREDENTIALS_MATCHER)
                     .includeCurrentValue(credentialsId);
         }
-
-        public FormValidation doCheckCredentialsId(@AncestorInPath SCMSourceOwner context,
+        
+        public FormValidation doCheckCredentialsId(@AncestorInPath Item context,
                                                    @QueryParameter String remote,
                                                    @QueryParameter String value) {
             if (context == null && !Jenkins.getActiveInstance().hasPermission(Jenkins.ADMINISTER) ||


### PR DESCRIPTION
If you pass the merge parameter as following:
Merge Before Build:
Name of repository : refs/remotes/origin
Branch to merge to : ${BRANCH_NAME}
Merge Strategy: default
Fast-forward mode: --ff

Here BRANCH_NAME is a String Parameter.
Then the output printed in console is something like:
Merging Revision 54f103b61f0b3504503f4990204f8dec8ea612ea (refs/remotes/origin/sample) to refs/remotes/origin/master, UserMergeOptions{mergeRemote='refs/remotes/origin', mergeTarget=**'${BRANCH_NAME}'**, mergeStrategy='default', fastForwardMode='--ff'}

With this Pull Request , the output is correct as the object is resolved correctly:
Merging Revision 54f103b61f0b3504503f4990204f8dec8ea612ea (refs/remotes/origin/sample) to refs/remotes/origin/master, UserMergeOptions{mergeRemote='refs/remotes/origin', mergeTarget='**master**', mergeStrategy='default', fastForwardMode='--ff'}